### PR TITLE
ci: cleanup deployment previews on PR close event

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,6 +35,14 @@ jobs: # NOTE - each job has their own runner which can be thought of an independ
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Extract Branch Name # NOTE -https://dev.to/thereis/how-to-remove-vercel-deployments-from-github-actions-4nfh
+        id: extract_branch
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      - name: Hash Branch Name
+        id: hash_branch
+        run: echo -n "hash=$(echo -n "${{ steps.extract_branch.outputs.branch }}" | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+
       - name: Set Up Node 18
         uses: actions/setup-node@v4
         with:
@@ -59,7 +67,9 @@ jobs: # NOTE - each job has their own runner which can be thought of an independ
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - name: Vercel Deploy
         id: deploy
-        run: echo "url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+        run: echo "url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --meta base_hash=${{ env.META_TAG }})" >> $GITHUB_OUTPUT
+        env:
+          META_TAG: ${{ steps.hash_branch.outputs.hash }}-${{ github.run_number }}-${{ github.run_attempt }}
 
       - name: Run Smoke Tests
         run: npm run test:e2e

--- a/.github/workflows/remove_pr_deployments.yaml
+++ b/.github/workflows/remove_pr_deployments.yaml
@@ -1,0 +1,36 @@
+name: Remove PR Preview Deployments
+
+permissions:
+  contents: read
+  statuses: write
+
+env:
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-deployments:
+    name: Delete Preview Deployments
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Extract Branch Name # NOTE -https://dev.to/thereis/how-to-remove-vercel-deployments-from-github-actions-4nfh
+        id: extract_branch
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      - name: Hash Branch Name
+        id: hash_branch
+        run: echo -n "hash=$(echo -n "${{ steps.extract_branch.outputs.branch }}" | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+
+      - name: Call delete-deployment-previews.sh script
+        env:
+          META_TAG: ${{ steps.hash_branch.outputs.hash }}
+        run: |
+          bash ./delete-deployment-previews.sh

--- a/delete-deployment-previews.sh
+++ b/delete-deployment-previews.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Set the pipefail option.
+set -o pipefail
+
+# Get the Vercel API endpoints.
+GET_DEPLOYMENTS_ENDPOINT="https://api.vercel.com/v6/deployments"
+DELETE_DEPLOYMENTS_ENDPOINT="https://api.vercel.com/v13/deployments"
+
+# Create a list of deployments.
+deployments=$(curl -s -X GET "$GET_DEPLOYMENTS_ENDPOINT/?projectId=$VERCEL_PROJECT_ID&teamId=$VERCEL_ORG_ID" -H "Authorization: Bearer $VERCEL_TOKEN")
+
+# Filter the deployments list by meta.base_hash === meta tag.
+filtered_deployments=$(echo $deployments | jq --arg META_TAG "$META_TAG" '[.deployments[] | select(.meta.base_hash | type == "string" and contains($META_TAG)) | .uid] | join(",")')
+filtered_deployments="${filtered_deployments//\"/}" # Remove double quotes
+
+# Clears the values from filtered_deployments
+IFS=',' read -ra values <<<"$filtered_deployments"
+
+echo "META_TAG ${META_TAG}"
+echo "Filtered deployments ${filtered_deployments}"
+
+# Iterate over the filtered deployments list.
+for uid in "${values[@]}"; do
+    echo "Deleting ${uid}"
+
+    delete_url=${DELETE_DEPLOYMENTS_ENDPOINT}/${uid}?teamId=${VERCEL_ORG_ID}
+    echo $delete_url
+
+    # Make DELETE a request to the /v13/deployments/{id} endpoint.
+    curl -X DELETE $delete_url -H "Authorization: Bearer $VERCEL_TOKEN"
+
+    echo "Deleted!"
+done


### PR DESCRIPTION
By default, Vercel does not automatically clean up old preview deployments. This commit introduces an automated process of cleaning up all preview deployments that are associated with a PR/branch name once the PR is closed out (e.g. PR gets merged into mainline or closed).

Largely pulled from https://dev.to/thereis/how-to-remove-vercel-deployments-from-github-actions-4nfh