### PR TITLE
chore: disable Vercel image optimization

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,6 +21,7 @@ const config = {
     defaultLocale: 'en',
   },
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'http',


### PR DESCRIPTION
Disable image optimization feature (for now) due to getting an alert about nearing the free-tier limit.