### PR TITLE
feat: add infinite scroll on episodes page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-iframe": "^1.8.5",
+        "react-intersection-observer": "^9.8.1",
         "rss-parser": "^3.12.0",
         "superjson": "1.12.2",
         "tailwind-merge": "^2.2.1",
@@ -24148,6 +24149,20 @@
       },
       "peerDependencies": {
         "react": ">=16.x.x"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.8.1.tgz",
+      "integrity": "sha512-QzOFdROX8D8MH3wE3OVKH0f3mLjKTtEN1VX/rkNuECCff+aKky0pIjulDhr3Ewqj5el/L+MhBkM3ef0Tbt+qUQ==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-iframe": "^1.8.5",
+    "react-intersection-observer": "^9.8.1",
     "rss-parser": "^3.12.0",
     "superjson": "1.12.2",
     "tailwind-merge": "^2.2.1",

--- a/src/components/EpisodesScreen.stories.ts
+++ b/src/components/EpisodesScreen.stories.ts
@@ -22,9 +22,7 @@ const mockEpisodes: EpisodeFeedItem[] = [...Array(50).keys()].map((i) => {
 
 export const LoadingEpisodes: Story = {
   args: {
-    showId: 1,
     title: 'Show title',
-    page: 1,
     isLoading: true,
   },
   play: async ({ canvasElement }) => {
@@ -36,9 +34,7 @@ export const LoadingEpisodes: Story = {
 
 export const NoEpisodesLoaded: Story = {
   args: {
-    showId: 1,
     title: 'Show title',
-    page: 1,
     isLoading: false,
   },
   play: async ({ canvasElement }) => {
@@ -50,9 +46,7 @@ export const NoEpisodesLoaded: Story = {
 
 export const EpisodesLoaded: Story = {
   args: {
-    showId: 1,
     title: 'Show title',
-    page: 1,
     isLoading: false,
     episodes: mockEpisodes,
   },
@@ -61,35 +55,31 @@ export const EpisodesLoaded: Story = {
 
     await expect(
       canvas.getByRole('heading', { level: 2 }).textContent,
-    ).toContain('Show title - Page 1')
+    ).toContain('Show title episodes')
     await expect(
       canvas.getAllByRole('link', { name: /episode/i }),
     ).toHaveLength(mockEpisodes.length)
   },
 }
 
-export const EpisodesLoadedWithPagination: Story = {
+export const LoadingMoreEpisodes: Story = {
   args: {
-    showId: 1,
     title: 'Show title',
-    page: 1,
     isLoading: false,
-    episodes: mockEpisodes,
-    nextPage: {
-      linkText: 'Page 2',
-      url: '',
-    },
+    episodes: mockEpisodes.slice(0, 10),
+    isFetchingNextPage: true,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
     await expect(
       canvas.getByRole('heading', { level: 2 }).textContent,
-    ).toContain('Show title - Page 1')
+    ).toContain('Show title episodes')
     await expect(
       canvas.getAllByRole('link', { name: /episode/i }),
-    ).toHaveLength(mockEpisodes.length)
-    await expect(canvas.getByRole('link', { name: '1' })).toBeInTheDocument()
-    await expect(canvas.getByRole('link', { name: '2' })).toBeInTheDocument()
+    ).toHaveLength(10)
+    await expect(
+      canvas.getByRole('img', { name: 'Loading' }),
+    ).toBeInTheDocument()
   },
 }

--- a/src/components/ui/spinner.stories.ts
+++ b/src/components/ui/spinner.stories.ts
@@ -1,0 +1,21 @@
+import { Spinner } from './spinner'
+import { type Meta, type StoryObj } from '@storybook/react'
+
+const meta: Meta<typeof Spinner> = {
+  component: Spinner,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof Spinner>
+
+export const DefaultSpinner: Story = {
+  args: {},
+}
+
+export const LargeSpinner: Story = {
+  args: {
+    size: 'lg',
+  },
+}

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,35 @@
+// NOTE https://github.com/shadcn-ui/ui/issues/697#issuecomment-1605883170
+import { type VariantProps, cva } from 'class-variance-authority'
+import { Loader2 } from 'lucide-react'
+import React from 'react'
+
+import { cn } from '~/lib/utils'
+
+const spinnerVariants = cva('animate-spin', {
+  variants: {
+    size: {
+      default: 'h-4 w-4',
+      lg: 'h-8 w-8',
+    },
+  },
+  defaultVariants: {
+    size: 'default',
+  },
+})
+
+export interface SpinnerProps
+  extends React.SVGAttributes<SVGSVGElement>,
+    VariantProps<typeof spinnerVariants> {}
+
+const Spinner = React.forwardRef<SVGSVGElement, SpinnerProps>(
+  ({ className, size }, ref) => {
+    return (
+      <div role='img' title='Loading' className={className}>
+        <Loader2 ref={ref} className={cn(spinnerVariants({ size }))} />
+      </div>
+    )
+  },
+)
+Spinner.displayName = 'Spinner'
+
+export { Spinner, spinnerVariants }

--- a/src/pages/episodes/[id].tsx
+++ b/src/pages/episodes/[id].tsx
@@ -9,19 +9,28 @@ const Episodes: NextPage = () => {
 
   const { id } = router.query
   const showId = parseInt(id as string)
-  const page = parseInt(router.query.page as string) || 1
 
-  const episodes = api.episodes.getEpisodes.useQuery({ showId, page })
-  const data = episodes.data
+  const { data, isLoading, isFetching, isFetchingNextPage, fetchNextPage } =
+    api.episodes.getEpisodes.useInfiniteQuery(
+      { showId },
+      {
+        getNextPageParam: (lastPage) => lastPage.nextPage,
+        initialCursor: 1,
+      },
+    )
+  const fetchedData = data?.pages.flat() || []
+  const episodes = fetchedData.flatMap((page) => page.episodes)
+  const title = fetchedData[0]?.title || ''
 
   return (
     <EpisodesScreen
-      showId={showId}
-      title={data?.title as string}
-      episodes={data?.episodes}
-      nextPage={data?.nextPage}
-      page={page}
-      isLoading={episodes.isLoading}
+      title={title}
+      episodes={episodes}
+      isLoading={isLoading}
+      isFetchingNextPage={isFetchingNextPage}
+      // NOTE adding "void" since we don't use the return value - https://github.com/orgs/react-hook-form/discussions/8622#discussioncomment-3950935
+      // also adding isFetching check as recommended practice - https://tanstack.com/query/latest/docs/framework/react/guides/infinite-queries
+      fetchNextPage={() => !isFetching && void fetchNextPage()}
     />
   )
 }

--- a/src/server/api/routers/episodes.ts
+++ b/src/server/api/routers/episodes.ts
@@ -5,24 +5,20 @@ import { z } from 'zod'
 
 import { env } from '~/env.mjs'
 import { createTRPCRouter, publicProcedure } from '~/server/api/trpc'
-import type {
-  EpisodeFeedItem,
-  EpisodeUrl,
-  ResourcePaginationLink,
-} from '~/utils/types'
+import type { EpisodeFeedItem, EpisodeUrl } from '~/utils/types'
 
 export const episodesRouter = createTRPCRouter({
   getEpisodes: publicProcedure
     .input(
       z.object({
         showId: z.number(),
-        page: z.number().min(1).optional().default(1),
+        cursor: z.number().min(1).optional().default(1),
       }),
     )
     .query(async ({ input }) => {
       const episodesResponse = await axios
         .get<string>(env.DATA_SOURCE_BASE_URL, {
-          params: { film: input.showId, nocache: 1, page: input.page },
+          params: { film: input.showId, nocache: 1, page: input.cursor },
         })
         .then((response) => response.data)
 
@@ -67,9 +63,9 @@ export const episodesRouter = createTRPCRouter({
         feedItems.length > 0 ? feedItems[feedItems.length - 1] : undefined
 
       const episodes = feedItems
-      let nextPage: ResourcePaginationLink | undefined = undefined
+      let nextPage: number | undefined = undefined
       if (lastEntry?.title.startsWith('Page ')) {
-        nextPage = { linkText: lastEntry.title, url: lastEntry.url }
+        nextPage = input.cursor + 1
         episodes.pop()
       }
 


### PR DESCRIPTION
This PR switches from a pagination component to infinite scrolling on the episodes page. A new `Spinner` UI component has been added as part of this work to enhance the UX of the infinite scroll.

Closes #23