### PR TITLE
ci: fix breaking deployment promotion

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -67,6 +67,6 @@ jobs:
           BASE_URL: ${{ steps.deploy.outputs.url }}
 
       - name: Promote Deployment
-        run: vercel promote $DEPLOYMENT_URL --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel promote $DEPLOYMENT_URL --token=${{ secrets.VERCEL_TOKEN }} --scope=cangkevins-projects
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
This commit fixes failing deployment promotion on Vercel due to a change that the platform made to accounts becoming teams. See https://vercel.com/changelog/2024-01-account-changes for more context.

Additionally, the `VERCEL_ORG_ID` environment variable in the CI builds needed to be updated with the Team ID associated with the new team per [this comment](https://github.com/orgs/vercel/discussions/3307#discussioncomment-6247423). For safe measures, we also created a new Vercel access token to be scoped to the new team that the project now lives under.