### PR TITLE
chore: add eslint-tailwind plugin

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,11 +18,12 @@ const config = {
   parserOptions: {
     project: path.join(__dirname, 'tsconfig.json'),
   },
-  plugins: ['@typescript-eslint', 'no-loops', 'unused-imports'],
+  plugins: ['@typescript-eslint', 'no-loops', 'unused-imports', 'tailwindcss'],
   extends: [
     'next/core-web-vitals',
     'plugin:@typescript-eslint/recommended',
     'plugin:storybook/recommended',
+    'plugin:tailwindcss/recommended',
   ],
   rules: {
     '@typescript-eslint/consistent-type-imports': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-storybook": "^0.6.15",
+        "eslint-plugin-tailwindcss": "^3.15.1",
         "eslint-plugin-unused-imports": "^2.0.0",
         "husky": "^8.0.3",
         "postcss": "^8.4.21",
@@ -15853,6 +15854,22 @@
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/eslint-plugin-tailwindcss": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.15.1.tgz",
+      "integrity": "sha512-4RXRMIaMG07C2TBEW1k0VM4+dDazz1kxcZhkK4zirvmHGZTA4jnlSO2kq5mamuSPi+Wo17dh2SlC8IyFBuCd7Q==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.5",
+        "postcss": "^8.4.4"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.4.0"
       }
     },
     "node_modules/eslint-plugin-unused-imports": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-storybook": "^0.6.15",
+    "eslint-plugin-tailwindcss": "^3.15.1",
     "eslint-plugin-unused-imports": "^2.0.0",
     "husky": "^8.0.3",
     "postcss": "^8.4.21",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -23,7 +23,7 @@ const buttonVariants = cva(
         default: 'h-10 px-4 py-2',
         sm: 'h-9 rounded-md px-3',
         lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10',
+        icon: 'size-10',
       },
     },
     defaultVariants: {

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -41,7 +41,7 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
 const NavigationMenuItem = NavigationMenuPrimitive.Item
 
 const navigationMenuTriggerStyle = cva(
-  'group inline-flex h-8 w-max items-center justify-center rounded-md bg-background px-2 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50',
+  'group inline-flex h-8 w-max items-center justify-center rounded-md bg-background p-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50',
 )
 
 const NavigationMenuTrigger = React.forwardRef<
@@ -55,7 +55,7 @@ const NavigationMenuTrigger = React.forwardRef<
   >
     {children}{' '}
     <ChevronDown
-      className='relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180'
+      className='relative top-px ml-1 size-3 transition duration-200 group-data-[state=open]:rotate-180'
       aria-hidden='true'
     />
   </NavigationMenuPrimitive.Trigger>
@@ -109,7 +109,7 @@ const NavigationMenuIndicator = React.forwardRef<
     )}
     {...props}
   >
-    <div className='relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md' />
+    <div className='relative top-[60%] size-2 rotate-45 rounded-tl-sm bg-border shadow-md' />
   </NavigationMenuPrimitive.Indicator>
 ))
 NavigationMenuIndicator.displayName =

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -70,7 +70,7 @@ const PaginationPrevious = ({
     className={cn('gap-1 pl-2.5', className)}
     {...props}
   >
-    <ChevronLeft className='h-4 w-4' />
+    <ChevronLeft className='size-4' />
     <span className='hidden md:inline'>Previous</span>
   </PaginationLink>
 )
@@ -87,7 +87,7 @@ const PaginationNext = ({
     {...props}
   >
     <span className='hidden md:inline'>Next</span>
-    <ChevronRight className='h-4 w-4' />
+    <ChevronRight className='size-4' />
   </PaginationLink>
 )
 PaginationNext.displayName = 'PaginationNext'
@@ -101,7 +101,7 @@ const PaginationEllipsis = ({
     className={cn('flex h-9 w-9 items-center justify-center', className)}
     {...props}
   >
-    <MoreHorizontal className='h-4 w-4' />
+    <MoreHorizontal className='size-4' />
     <span className='sr-only'>More pages</span>
   </span>
 )

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -12,7 +12,7 @@ const ScrollArea = React.forwardRef<
     className={cn('relative overflow-hidden', className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className='h-full w-full rounded-[inherit]'>
+    <ScrollAreaPrimitive.Viewport className='size-full rounded-[inherit]'>
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -8,8 +8,8 @@ import { cn } from '~/lib/utils'
 const spinnerVariants = cva('animate-spin', {
   variants: {
     size: {
-      default: 'h-4 w-4',
-      lg: 'h-8 w-8',
+      default: 'size-4',
+      lg: 'size-8',
     },
   },
   defaultVariants: {


### PR DESCRIPTION
This PR adds [`eslint-plugin-tailwind`](https://github.com/francoismassart/eslint-plugin-tailwindcss) to have active linting on our TailwindCSS usage.

Additionally, all linting warnings that were picked up have been fixed as well.