### PR TITLE
feat: add Vercel analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@trpc/next": "^10.18.0",
         "@trpc/react-query": "^10.18.0",
         "@trpc/server": "^10.18.0",
+        "@vercel/analytics": "^1.3.1",
         "axios": "^1.3.4",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
@@ -10657,6 +10658,26 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.3.1.tgz",
+      "integrity": "sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==",
+      "dependencies": {
+        "server-only": "^0.0.1"
+      },
+      "peerDependencies": {
+        "next": ">= 13",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "0.34.7",
@@ -25440,6 +25461,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@trpc/next": "^10.18.0",
     "@trpc/react-query": "^10.18.0",
     "@trpc/server": "^10.18.0",
+    "@vercel/analytics": "^1.3.1",
     "axios": "^1.3.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import Footer from './Footer'
 import Header from './Header'
+import { Analytics } from '@vercel/analytics/react'
 import Head from 'next/head'
 import React from 'react'
 
@@ -17,7 +18,10 @@ const Layout = ({ children }: LayoutProps) => {
       </Head>
 
       <Header categories={categories} />
-      <main className='grid min-h-[calc(100dvh-6rem)]'>{children}</main>
+      <main className='grid min-h-[calc(100dvh-6rem)]'>
+        {children}
+        <Analytics />
+      </main>
       <Footer />
     </>
   )


### PR DESCRIPTION
This PR adds [Vercel Web Analytics](https://vercel.com/docs/analytics/quickstart) to take advantage of the [limits on the hobby plan](https://vercel.com/docs/analytics/limits-and-pricing#pricing-for-web-analytics) for tracking users and page views.